### PR TITLE
Send browser User-Agent when fetching YouTube RSS feeds

### DIFF
--- a/scripts/fetch-feed.mjs
+++ b/scripts/fetch-feed.mjs
@@ -33,7 +33,9 @@ const mapConcurrent = async (items, limit, worker) => {
 const fetchChannelFeed = async (channel) => {
   const url = `https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`;
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0 (feed-builder)" },
+    });
     if (!res.ok) {
       console.warn(`[feed] ${channel.title || channel.id}: HTTP ${res.status}`);
       return [];


### PR DESCRIPTION
YouTube's feeds/videos.xml endpoint rejects the default Node fetch
User-Agent with HTTP 404, causing the daily job to produce an empty
subscription-feed.json. Pass the same Mozilla UA the shorts probe
already uses.

https://claude.ai/code/session_018JvgykgYvom6H3ji6sPkRh