### PR TITLE
Add email verification to Google OAuth callback

### DIFF
--- a/functions/api/auth/callback.ts
+++ b/functions/api/auth/callback.ts
@@ -4,6 +4,15 @@ const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 365;
 
 interface Env {
   GOOGLE_CLIENT_SECRET: string;
+  ALLOWED_EMAIL: string;
+}
+
+function decodeIdTokenEmail(idToken: string): { email?: string; email_verified?: boolean } {
+  const payload = idToken.split(".")[1];
+  if (!payload) return {};
+  const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  return JSON.parse(atob(padded));
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -31,7 +40,22 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     access_token: string;
     refresh_token: string;
     expires_in: number;
+    id_token?: string;
   }>();
+
+  if (!tokens.id_token) {
+    return new Response("Missing id_token — ensure 'openid email' scopes are requested", { status: 400 });
+  }
+
+  const allowed = context.env.ALLOWED_EMAIL?.trim().toLowerCase();
+  if (!allowed) {
+    return new Response("Server misconfigured: ALLOWED_EMAIL is not set", { status: 500 });
+  }
+
+  const { email, email_verified } = decodeIdTokenEmail(tokens.id_token);
+  if (!email_verified || email?.toLowerCase() !== allowed) {
+    return new Response("Forbidden", { status: 403 });
+  }
 
   if (!tokens.refresh_token) {
     return new Response("No refresh token returned — re-authorize with prompt=consent", { status: 400 });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,7 +4,7 @@ import useStore from "../helpers/store";
 
 const REFRESH_LEAD_MS = 5 * 60 * 1000;
 const SCOPE =
-  "https://www.googleapis.com/auth/youtube.readonly https://www.googleapis.com/auth/youtube.force-ssl";
+  "openid email https://www.googleapis.com/auth/youtube.readonly https://www.googleapis.com/auth/youtube.force-ssl";
 
 export default function useAuth() {
   const setAccessToken = useStore((s) => s.setAccessToken);
@@ -50,7 +50,11 @@ export default function useAuth() {
         body: JSON.stringify({ code: res.code }),
       });
       if (!callbackRes.ok) {
-        console.error("Auth callback failed:", await callbackRes.text());
+        const message = await callbackRes.text();
+        console.error("Auth callback failed:", message);
+        if (callbackRes.status === 403) {
+          alert("This application is restricted to its owner. Your Google account is not authorized.");
+        }
         return;
       }
       const data: { accessToken: string; expiresIn: number } =


### PR DESCRIPTION
## Summary
This PR adds email-based access control to the OAuth authentication flow, restricting the application to a specific authorized email address.

## Key Changes
- **Backend (callback.ts)**:
  - Added `ALLOWED_EMAIL` constant to define the authorized email address
  - Implemented `decodeIdTokenEmail()` function to extract and parse the email claim from the JWT id_token
  - Added validation to ensure `id_token` is present in the token response (requires 'openid email' scopes)
  - Added email verification check that returns 403 Forbidden if the email is not verified or doesn't match the allowed email

- **Frontend (useAuth.ts)**:
  - Updated OAuth scope to include `openid email` to request the id_token and email claims from Google
  - Improved error handling in the auth callback to distinguish between different failure types
  - Added user-facing alert message for 403 Forbidden responses to inform users they are not authorized

## Implementation Details
- The id_token is manually decoded by splitting the JWT, base64-decoding the payload, and parsing the JSON claims
- Email comparison is case-insensitive to handle variations in email formatting
- The application now requires explicit email verification from Google's OAuth provider before granting access

https://claude.ai/code/session_01Ekd7K2zLxJ5kii2N99GznB