### PR TITLE
Prevent duplicate video fetches when videos already loaded

### DIFF
--- a/src/components/Videos.tsx
+++ b/src/components/Videos.tsx
@@ -108,10 +108,12 @@ export default function Videos() {
   };
 
   useEffect(() => {
+    if (!selectedPlaylist || videos.length > 0) return;
     fetchNextPlaylistVideos();
   }, [selectedPlaylist]);
 
   useEffect(() => {
+    if (!selectedSubscription || videos.length > 0) return;
     fetchNextChannelVideos();
   }, [selectedSubscription]);
 


### PR DESCRIPTION
## Summary
Add early-return guards to the playlist and subscription video fetch effects to prevent redundant API calls when videos have already been loaded for the current view.

## Changes
- Added `if (!selectedPlaylist || videos.length > 0) return;` guard to the `selectedPlaylist` effect in `Videos.tsx` to skip fetching if videos are already present
- Added `if (!selectedSubscription || videos.length > 0) return;` guard to the `selectedSubscription` effect in `Videos.tsx` to skip fetching if videos are already present

## Details
These guards prevent the effects from triggering unnecessary `fetchNextPlaylistVideos()` and `fetchNextChannelVideos()` API calls when the `videos` array already contains data. This is particularly useful during component re-renders or when the selected playlist/subscription hasn't actually changed, reducing unnecessary network requests and improving performance.

https://claude.ai/code/session_01MQf1yt2w1mEcmN7zj9XkRd