### PR TITLE
Add scheduled downtime notice (22:00–12:00 UK time)

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,10 +1,23 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import useStore from "../helpers/store";
 import useAuth from "../hooks/useAuth";
 import { fetchSubscriptionsAPI } from "../helpers/youtubeAPI/subscriptionAPI";
 import { fetchUserAPI } from "../helpers/youtubeAPI/userAPI";
+import DowntimeNotice from "./DowntimeNotice";
 import HomePage from "./HomePage";
 import LandingPage from "./LandingPage";
+
+// Site is offline between 22:00 and 12:00 Europe/London time.
+const isDowntime = () => {
+  const hour = Number(
+    new Intl.DateTimeFormat("en-GB", {
+      timeZone: "Europe/London",
+      hour: "2-digit",
+      hourCycle: "h23",
+    }).format(new Date()),
+  );
+  return hour >= 22 || hour < 12;
+};
 
 const App = () => {
   const accessToken = useStore((state) => state.accessToken);
@@ -12,6 +25,12 @@ const App = () => {
   const setUser = useStore((state) => state.setUser);
   const setSubscriptions = useStore((state) => state.setSubscriptions);
   const login = useAuth();
+  const [downtime, setDowntime] = useState(isDowntime);
+
+  useEffect(() => {
+    const id = setInterval(() => setDowntime(isDowntime()), 60_000);
+    return () => clearInterval(id);
+  }, []);
 
   useEffect(() => {
     if (!accessToken) return;
@@ -27,6 +46,8 @@ const App = () => {
       setSubscriptions(subs);
     });
   }, [accessToken, setUser, setSubscriptions]);
+
+  if (downtime) return <DowntimeNotice />;
 
   if (authLoading) return null;
 

--- a/src/components/DowntimeNotice.tsx
+++ b/src/components/DowntimeNotice.tsx
@@ -1,0 +1,15 @@
+const DowntimeNotice = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-base-200 p-6">
+      <div className="max-w-md text-center">
+        <h1 className="text-3xl font-bold mb-4">We&apos;re taking a break</h1>
+        <p className="text-base-content/80">
+          This site is unavailable between 10:00 PM and 12:00 PM (UK time).
+          Please come back during opening hours.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default DowntimeNotice;


### PR DESCRIPTION
## Summary
Adds a scheduled downtime feature that displays a notice to users when the site is offline between 22:00 and 12:00 Europe/London time.

## Changes
- **New component `DowntimeNotice.tsx`**: Displays a centered message informing users the site is unavailable during the scheduled downtime window.
- **Updated `App.tsx`**:
  - Added `isDowntime()` helper function that checks the current hour in Europe/London timezone and returns `true` if between 22:00–23:59 or 00:00–11:59.
  - Added `downtime` state initialized with the current downtime status.
  - Added `useEffect` hook that polls `isDowntime()` every 60 seconds to keep the status in sync across timezone boundaries and time changes.
  - Added early return in render that shows `<DowntimeNotice />` if `downtime` is `true`, preventing access to the app during offline hours.

## Implementation Details
- The downtime check uses `Intl.DateTimeFormat` with `timeZone: "Europe/London"` to ensure consistent behavior regardless of the user's local timezone.
- The polling interval (60 seconds) ensures the notice appears/disappears promptly when crossing the downtime boundary.
- The check happens before auth loading and token validation, so users see the notice immediately if the site is offline.

https://claude.ai/code/session_014WnnogwNWYnJvGp41RqRix