### PR TITLE
Adjust site downtime window from 22:00-12:00 to 22:00-10:00

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,7 +7,7 @@ import DowntimeNotice from "./DowntimeNotice";
 import HomePage from "./HomePage";
 import LandingPage from "./LandingPage";
 
-// Site is offline between 22:00 and 12:00 Europe/London time.
+// Site is offline between 22:00 and 10:00 Europe/London time.
 const isDowntime = () => {
   const hour = Number(
     new Intl.DateTimeFormat("en-GB", {
@@ -16,7 +16,7 @@ const isDowntime = () => {
       hourCycle: "h23",
     }).format(new Date()),
   );
-  return hour >= 22 || hour < 12;
+  return hour >= 22 || hour < 10;
 };
 
 const App = () => {

--- a/src/components/DowntimeNotice.tsx
+++ b/src/components/DowntimeNotice.tsx
@@ -4,7 +4,7 @@ const DowntimeNotice = () => {
       <div className="max-w-md text-center">
         <h1 className="text-3xl font-bold mb-4">We&apos;re taking a break</h1>
         <p className="text-base-content/80">
-          This site is unavailable between 10:00 PM and 12:00 PM (UK time).
+          This site is unavailable between 10:00 PM and 10:00 AM (UK time).
           Please come back during opening hours.
         </p>
       </div>


### PR DESCRIPTION
## Summary
Updates the scheduled downtime window for the site from 22:00 PM to 12:00 PM (UK time) to 22:00 PM to 10:00 AM (UK time), shifting the end of the maintenance window 2 hours earlier.

## Changes
- **App.tsx**: Updated the downtime check logic to use `hour < 10` instead of `hour < 12`, and updated the corresponding comment to reflect the new 10:00 AM end time
- **DowntimeNotice.tsx**: Updated the user-facing message to display the correct downtime window (10:00 PM to 10:00 AM instead of 10:00 PM to 12:00 PM)

## Details
The `isDowntime()` function in `App.tsx` now correctly identifies the downtime period as any hour where `hour >= 22 || hour < 10` (using 24-hour format), which represents 22:00 through 09:59 UK time. The `DowntimeNotice` component displays this updated window to users when the site is in maintenance mode.

https://claude.ai/code/session_014EuCzQ8s5KJUK2yYnutT9c