### PR TITLE
Add video description display and increase comment limit

### DIFF
--- a/src/components/VideoViewer.tsx
+++ b/src/components/VideoViewer.tsx
@@ -6,7 +6,7 @@ import {
 } from "../helpers/resumePosition";
 import useStore from "../helpers/store";
 import { loadYouTubeIframeApi } from "../helpers/youtubeIframeApi";
-import { fetchVideoCommentsAPI } from "../helpers/youtubeAPI/videoAPI";
+import { fetchVideoCommentsAPI, fetchVideoDescriptionAPI } from "../helpers/youtubeAPI/videoAPI";
 
 
 interface VideoViewerProps {
@@ -25,6 +25,7 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
   const sidebarOpen = useStore((state) => state.sidebarOpen);
   const [comments, setComments] = useState<VideoComment[]>([]);
   const [loadingComments, setLoadingComments] = useState(false);
+  const [description, setDescription] = useState("");
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const playerRef = useRef<YT.Player | null>(null);
   const playerReadyRef = useRef(false);
@@ -58,6 +59,19 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
       setLoadingComments(false);
     };
     fetchComments();
+  }, [accessToken, video.resourceId]);
+
+  useEffect(() => {
+    const fetchDescription = async () => {
+      if (!accessToken) return;
+      setDescription("");
+      const fetchedDescription = await fetchVideoDescriptionAPI(
+        accessToken,
+        video.resourceId
+      );
+      setDescription(fetchedDescription);
+    };
+    fetchDescription();
   }, [accessToken, video.resourceId]);
 
   useEffect(() => {
@@ -270,6 +284,14 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
             />
           </div>
         </div>
+        {!pip && description && (
+          <div className="mt-4">
+            <h3 className="font-semibold text-base mb-3">Description</h3>
+            <p className="text-sm whitespace-pre-wrap break-words text-base-content/80">
+              {description}
+            </p>
+          </div>
+        )}
         {!pip && (
         <div className="mt-4">
           <h3 className="font-semibold text-base mb-3">Top Comments</h3>

--- a/src/helpers/youtubeAPI/videoAPI.ts
+++ b/src/helpers/youtubeAPI/videoAPI.ts
@@ -16,7 +16,7 @@ export const fetchVideoCommentsAPI = async (
         params: {
           part: "snippet",
           videoId,
-          maxResults: 5,
+          maxResults: 10,
           order: "relevance",
         },
       }
@@ -49,6 +49,30 @@ export const fetchVideoCommentsAPI = async (
   } catch (error) {
     console.error("Error fetching comments:", error);
     return [];
+  }
+};
+
+export const fetchVideoDescriptionAPI = async (
+  accessToken: string,
+  videoId: string
+): Promise<string> => {
+  try {
+    const result = await axios.get(
+      "https://www.googleapis.com/youtube/v3/videos",
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        params: {
+          part: "snippet",
+          id: videoId,
+        },
+      }
+    );
+    return result.data.items[0]?.snippet?.description ?? "";
+  } catch (error) {
+    console.error("Error fetching video description:", error);
+    return "";
   }
 };
 


### PR DESCRIPTION
## Summary
Adds the ability to fetch and display video descriptions in the VideoViewer component, and increases the default comment fetch limit from 5 to 10 results.

## Changes
- **New API function**: `fetchVideoDescriptionAPI` in `videoAPI.ts` fetches video descriptions from the YouTube Data API v3 using the `snippet` part
- **VideoViewer integration**: Added description state management and a `useEffect` hook to fetch descriptions when the video or access token changes
- **UI rendering**: Display description below the comments section (hidden in picture-in-picture mode) with proper text formatting (`whitespace-pre-wrap` to preserve formatting)
- **Comment limit**: Increased `maxResults` from 5 to 10 in `fetchVideoCommentsAPI` to show more top comments by relevance

## Implementation Details
- Description fetching follows the same error-handling pattern as other API functions (returns empty string on failure)
- Description state is cleared before fetching to avoid stale data
- The description display is conditionally rendered only when not in PiP mode and description is available
- Uses the existing `fetchVideoDescriptionAPI` import pattern consistent with other API calls in the codebase

https://claude.ai/code/session_01FrkTHsYJssgZosgPKn1aEz