### PR TITLE
Add expandable description with overflow detection in VideoViewer

### DIFF
--- a/src/components/VideoViewer.tsx
+++ b/src/components/VideoViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { convertReleaseDateToTimeSinceRelease } from "../helpers/functions";
 import {
   getResumePosition,
@@ -26,6 +26,9 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
   const [comments, setComments] = useState<VideoComment[]>([]);
   const [loadingComments, setLoadingComments] = useState(false);
   const [description, setDescription] = useState("");
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [descriptionOverflows, setDescriptionOverflows] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const playerRef = useRef<YT.Player | null>(null);
   const playerReadyRef = useRef(false);
@@ -65,6 +68,8 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
     const fetchDescription = async () => {
       if (!accessToken) return;
       setDescription("");
+      setDescriptionExpanded(false);
+      setDescriptionOverflows(false);
       const fetchedDescription = await fetchVideoDescriptionAPI(
         accessToken,
         video.resourceId
@@ -73,6 +78,17 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
     };
     fetchDescription();
   }, [accessToken, video.resourceId]);
+
+  useLayoutEffect(() => {
+    const el = descriptionRef.current;
+    if (!el || !description) {
+      setDescriptionOverflows(false);
+      return;
+    }
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+    if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
+    setDescriptionOverflows(el.scrollHeight > lineHeight * 5 + 1);
+  }, [description]);
 
   useEffect(() => {
     let cancelled = false;
@@ -287,9 +303,20 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
         {!pip && description && (
           <div className="mt-4">
             <h3 className="font-semibold text-base mb-3">Description</h3>
-            <p className="text-sm whitespace-pre-wrap break-words text-base-content/80">
+            <p
+              ref={descriptionRef}
+              className={`text-sm whitespace-pre-wrap break-words text-base-content/80 ${descriptionOverflows && !descriptionExpanded ? "line-clamp-5" : ""}`}
+            >
               {description}
             </p>
+            {descriptionOverflows && (
+              <button
+                className="mt-2 text-sm font-medium text-primary hover:underline"
+                onClick={() => setDescriptionExpanded((v) => !v)}
+              >
+                {descriptionExpanded ? "Show less" : "Read more"}
+              </button>
+            )}
           </div>
         )}
         {!pip && (


### PR DESCRIPTION
## Summary
Adds the ability to expand/collapse video descriptions that exceed 5 lines, improving readability for lengthy descriptions in the VideoViewer component.

## Key Changes
- Added state management for description expansion (`descriptionExpanded`) and overflow detection (`descriptionOverflows`)
- Implemented `useLayoutEffect` hook to detect when description text overflows beyond 5 lines by comparing `scrollHeight` against computed line height
- Added a "Read more" / "Show less" toggle button that appears only when description content overflows
- Applied `line-clamp-5` CSS class conditionally to truncate descriptions when collapsed
- Reset expansion state when a new video description is fetched
- Imported `useLayoutEffect` from React for DOM measurement operations

## Implementation Details
- Uses `useLayoutEffect` (rather than `useEffect`) to measure the description element synchronously before paint, ensuring accurate overflow detection
- Calculates overflow by comparing element's `scrollHeight` against `lineHeight * 5 + 1` to account for the 5-line limit
- Safely handles edge cases: validates that `lineHeight` is a finite positive number before using it
- Button styling uses Tailwind's `text-primary` with hover underline for consistency with the design system

https://claude.ai/code/session_01SsmPWq4aq3P9bEiGV4rtx4