### PR TITLE
Add search page with video results

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -71,6 +71,7 @@ type CurrentView =
   | { type: 'channel'; subscription: Subscription }
   | { type: 'subscriptions' }
   | { type: 'feed' }
+  | { type: 'search' }
   | { type: 'none' };
 
 type FeedVideo = {

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -3,6 +3,7 @@ import useStore from "../helpers/store";
 import { fetchVideoByIdAPI } from "../helpers/youtubeAPI/videoAPI";
 import Nav from "./Nav";
 import Sidebar from "./Sidebar";
+import Search from "./Search";
 import Subscriptions from "./Subscriptions";
 import SubscriptionFeed from "./SubscriptionFeed";
 import VideoViewer from "./VideoViewer";
@@ -34,6 +35,8 @@ export default function HomePage() {
 
     if (routeType === "subscriptions") {
       setCurrentView({ type: "subscriptions" });
+    } else if (routeType === "search") {
+      setCurrentView({ type: "search" });
     } else if (routeType === "channel" && routeId) {
       setCurrentView({
         type: "channel",
@@ -97,6 +100,7 @@ export default function HomePage() {
   const renderMain = () => {
     if (currentView.type === "feed") return <SubscriptionFeed />;
     if (currentView.type === "subscriptions") return <Subscriptions />;
+    if (currentView.type === "search") return <Search />;
     return <Videos />;
   };
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useState } from "react";
+import useStore from "../helpers/store";
+import { searchVideosAPI } from "../helpers/youtubeAPI/videoAPI";
+import MoveDropdown from "./MoveDropdown";
+import VideoActions from "./VideoActions";
+import VideoRow from "./VideoRow";
+
+export default function Search() {
+  const accessToken = useStore((state) => state.accessToken);
+  const gridView = useStore((state) => state.gridView);
+  const viewingVideo = useStore((state) => state.viewingVideo);
+  const setViewingVideo = useStore((state) => state.setViewingVideo);
+  const videoViewerPip = useStore((state) => state.videoViewerPip);
+  const subscriptions = useStore((state) => state.subscriptions);
+  const setCurrentView = useStore((state) => state.setCurrentView);
+
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Video[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed || !accessToken) return;
+
+    setLoading(true);
+    setSelectedIds(new Set());
+    const videos = await searchVideosAPI(accessToken, trimmed);
+    setResults(videos);
+    setHasSearched(true);
+    setLoading(false);
+  };
+
+  const handleDragStart = (e: React.DragEvent, video: Video) => {
+    e.dataTransfer.setData(
+      "video",
+      JSON.stringify({
+        videoId: video.resourceId,
+        sourcePlaylistId: undefined,
+        videoItemId: undefined,
+      }),
+    );
+
+    const dragImage = document.createElement("img");
+    dragImage.style.position = "absolute";
+    dragImage.style.top = "-9999px";
+    dragImage.style.left = "-9999px";
+    dragImage.src = video.thumbnail;
+    e.dataTransfer.setDragImage(dragImage, 20, 20);
+  };
+
+  const handleChannelClick = useCallback(
+    (channelId: string, channelTitle: string) => {
+      const match = subscriptions.find((s) => s.channelId === channelId);
+      const subscription =
+        match ?? { id: "", title: channelTitle, thumbnail: "", channelId };
+      setCurrentView({ type: "channel", subscription });
+    },
+    [subscriptions, setCurrentView],
+  );
+
+  return (
+    <div
+      className={`pt-4 px-4 md:pt-10 md:px-10 overflow-y-auto flex-col ${
+        viewingVideo && !videoViewerPip ? "hidden xl:flex xl:w-1/2" : "flex w-full"
+      }`}
+    >
+      <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-3 mb-4">
+        <form onSubmit={handleSearch} className="flex flex-row gap-2 flex-1 min-w-0">
+          <input
+            type="text"
+            className="input input-bordered flex-1 min-w-0"
+            placeholder="Search YouTube..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={loading || !query.trim()}
+          >
+            {loading && <span className="loading loading-spinner"></span>}
+            Search
+          </button>
+        </form>
+        {results.length > 0 && (
+          <VideoActions
+            selectedCount={selectedIds.size}
+            totalCount={results.length}
+            onSelectAll={() => setSelectedIds(new Set(results.map((v) => v.id)))}
+            onDeselectAll={() => setSelectedIds(new Set())}
+            moveDropdown={
+              <MoveDropdown
+                selectedVideoResourceIds={Array.from(selectedIds)}
+                onComplete={() => setSelectedIds(new Set())}
+              />
+            }
+          />
+        )}
+      </div>
+      <div className="overflow-y-auto">
+        {loading && (
+          <div className="flex items-center justify-center py-10">
+            <span className="loading loading-spinner loading-lg"></span>
+          </div>
+        )}
+        {!loading && hasSearched && results.length === 0 && (
+          <p className="text-sm text-base-content/60">
+            No videos found. Try a different search.
+          </p>
+        )}
+        {!loading && !hasSearched && (
+          <p className="text-sm text-base-content/60">
+            Search for videos and drag them into a playlist, or select and move them.
+          </p>
+        )}
+        {!loading && results.length > 0 && (
+          <ul
+            className={
+              gridView
+                ? "grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4"
+                : "flex flex-col"
+            }
+          >
+            {results.map((video, i) => (
+              <VideoRow
+                key={video.id}
+                video={video}
+                index={i}
+                gridView={gridView}
+                selected={selectedIds.has(video.id)}
+                onToggleSelect={() => toggleSelected(video.id)}
+                onOpenViewer={() => setViewingVideo(video)}
+                onDragStart={(e) => handleDragStart(e, video)}
+                onChannelClick={handleChannelClick}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ export default function Sidebar() {
 
   const isFeed = currentView.type === "feed";
   const isSubscriptions = currentView.type === "subscriptions";
+  const isSearch = currentView.type === "search";
 
   useEffect(() => {
     let startX: number | null = null;
@@ -108,6 +109,19 @@ export default function Sidebar() {
           }}
         >
           Subscriptions
+        </button>
+        <button
+          className={`w-full p-2 rounded-md hover:bg-neutral/10 text-base text-left font-semibold ${isSearch ? "bg-neutral/10" : ""}`}
+          onClick={() => {
+            setCurrentView({ type: "search" });
+            setSidebarOpen(false);
+            if (window.innerWidth < 768 && viewingVideo) setVideoViewerPip(true);
+            const url = new URL(window.location.href);
+            url.pathname = "/search";
+            window.history.pushState({}, "", url.toString());
+          }}
+        >
+          Search
         </button>
       </div>
       <div className="divider my-0 mx-4"></div>

--- a/src/helpers/youtubeAPI/videoAPI.ts
+++ b/src/helpers/youtubeAPI/videoAPI.ts
@@ -209,6 +209,51 @@ export const fetchChannelVideosAPI = async (
   }
 };
 
+export const searchVideosAPI = async (
+  accessToken: string,
+  query: string
+): Promise<Video[]> => {
+  try {
+    const searchResult = await axios.get(
+      "https://www.googleapis.com/youtube/v3/search",
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        params: {
+          part: "snippet",
+          q: query,
+          order: "relevance",
+          type: "video",
+          maxResults: 25,
+        },
+      }
+    );
+
+    const videoIds: string[] = searchResult.data.items
+      .map((item: { id: { videoId: string } }) => item.id.videoId)
+      .filter(Boolean);
+
+    if (videoIds.length === 0) {
+      return [];
+    }
+
+    const hydrated = await fetchVideoDetailsAPI(accessToken, videoIds);
+
+    // Preserve the relevance order returned by the search endpoint.
+    const byId = new Map(hydrated.map((video) => [video.id, video]));
+    const ordered = videoIds
+      .map((id) => byId.get(id))
+      .filter((video): video is Video => video !== undefined);
+
+    // Exclude Shorts (<= 60s) and keep the ten most relevant results.
+    return ordered.filter((video) => video.durationSeconds > 60).slice(0, 10);
+  } catch (error) {
+    console.error("Error searching videos:", error);
+    return [];
+  }
+};
+
 export const addVideosToPlaylistAPI = async (
   accessToken: string,
   videoIds: string[],


### PR DESCRIPTION
Add a Search view linked below Subscriptions in the sidebar. It has a
search bar that queries the YouTube Data API for the ten most relevant
videos (Shorts excluded by filtering out clips <= 60s) and renders them
with title, channel, view count, and upload age via the shared VideoRow.
Results support drag-into-playlist and select-and-move like the feed.

https://claude.ai/code/session_01PADVJqY175iFWdGSXxHYuw