### PR TITLE
Filter out YouTube Shorts from channel videos list

### DIFF
--- a/src/helpers/youtubeAPI/videoAPI.ts
+++ b/src/helpers/youtubeAPI/videoAPI.ts
@@ -200,7 +200,10 @@ export const fetchChannelVideosAPI = async (
       return { videos: [], nextPageToken: null };
     }
 
-    const videos = await fetchVideoDetailsAPI(accessToken, videoIds);
+    const hydrated = await fetchVideoDetailsAPI(accessToken, videoIds);
+
+    // Exclude Shorts (<= 60s) from the channel videos list.
+    const videos = hydrated.filter((video) => video.durationSeconds > 60);
 
     return { videos, nextPageToken: searchResult.data.nextPageToken ?? null };
   } catch (error) {


### PR DESCRIPTION
## Summary
Exclude YouTube Shorts (videos ≤ 60 seconds) from the channel videos list to provide a cleaner viewing experience and align with how the subscription feed already filters Shorts.

## Changes
- Modified `fetchChannelVideosAPI` in `src/helpers/youtubeAPI/videoAPI.ts` to filter out videos with duration ≤ 60 seconds after hydrating video details
- The hydrated video details are now stored in a `hydrated` variable, then filtered to exclude Shorts before returning

## Implementation Details
The filter is applied after `fetchVideoDetailsAPI` returns, which already provides `durationSeconds` for each video. This leverages the existing duration parsing infrastructure and maintains consistency with the subscription feed's Shorts-filtering logic (which probes `youtube.com/shorts/<id>` to detect Shorts).

https://claude.ai/code/session_01VXRWAaY6TMof7ezcW7mN3u