### PR TITLE
Add recommended feed from YouTube home page

### DIFF
--- a/.github/workflows/fetch-feed.yml
+++ b/.github/workflows/fetch-feed.yml
@@ -29,13 +29,25 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
 
-      - name: Commit updated feed
+      # continue-on-error: an expired YOUTUBE_COOKIE must not block the
+      # subscription feed refresh. On failure the previous recommended-feed
+      # JSON simply stays in place.
+      - name: Fetch recommended feed
+        continue-on-error: true
+        run: node scripts/fetch-recommended.mjs
+        env:
+          YOUTUBE_COOKIE: ${{ secrets.YOUTUBE_COOKIE }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+
+      - name: Commit updated feeds
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if [[ -n "$(git status --porcelain public/subscription-feed.json)" ]]; then
-            git add public/subscription-feed.json
-            git commit -m "chore: refresh subscription feed"
+          if [[ -n "$(git status --porcelain public/subscription-feed.json public/recommended-feed.json)" ]]; then
+            git add public/subscription-feed.json public/recommended-feed.json
+            git commit -m "chore: refresh feeds"
             git push
           else
             echo "No changes to commit."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,15 @@ Videos from the playlist-items endpoint only include snippet data, so `fetchVide
 
 ### Subscription feed (offline pipeline)
 
-`SubscriptionFeed.tsx` does NOT call the YouTube Data API. Instead it `fetch`es `/subscription-feed.json`, a static file generated out-of-band by `scripts/fetch-feed.mjs` (Node, uses `fast-xml-parser`).
+`StaticFeed.tsx` does NOT call the YouTube Data API. It is a generic component that `fetch`es a static JSON file (`/subscription-feed.json` for the "Recent Feed" view, `/recommended-feed.json` for the "Recommended" view, both `StaticFeedData`-shaped). The subscription feed file is generated out-of-band by `scripts/fetch-feed.mjs` (Node, uses `fast-xml-parser`).
 
 The script pulls the subscription list live from the YouTube Data API (`subscriptions.list?mine=true`, paginated) using a refresh token stored in GitHub Actions secrets. It exchanges `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` + `GOOGLE_REFRESH_TOKEN` for an access token at the start of the run, then hits each channel's public RSS feed (`youtube.com/feeds/videos.xml?channel_id=…`) with 4-way concurrency, dedupes, sorts by `releaseDate` desc, then filters out Shorts by probing `youtube.com/shorts/<id>` with `redirect: "manual"` (status 200 = Short, 3xx = regular video). It keeps the top 100 and writes `public/subscription-feed.json`. The "refresh subscription feed" commits are regenerations of this file. If the OAuth call or `subscriptions.list` fails the run aborts — there is no static fallback list.
 
 Consequence: the feed is read-only and only as fresh as the last script run; drag-out of a feed video into a playlist works (via the same `dataTransfer` contract as `Videos.tsx`) but no upload/move-from-feed equivalent exists on the server side.
+
+### Recommended feed (offline pipeline)
+
+`scripts/fetch-recommended.mjs` generates `public/recommended-feed.json` (max 50 videos, kept in YouTube's recommendation ranking order — the "Recommended" view hides the sort dropdown and does not sort). It uses `youtubei.js` (unofficial Innertube API) authenticated with a logged-in youtube.com `Cookie` header from the `YOUTUBE_COOKIE` GitHub Actions secret to harvest video IDs from the personalized Home feed, then hydrates titles/dates/view counts through the official Data API `videos.list` using the same refresh-token OAuth exchange as `fetch-feed.mjs`. Shorts (≤61s), live streams, Mixes, and playlists are filtered out. The script verifies the cookie actually authenticates (`yt.account.getInfo()`) and aborts without writing otherwise — an expired cookie leaves the previous JSON in place instead of replacing it with the generic logged-out feed. The workflow step runs with `continue-on-error: true` so a cookie failure never blocks the subscription refresh. Cookies expire every few weeks-to-months; renew by re-copying the `Cookie` request header from devtools into the secret.
 
 ### Drag-and-drop
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -71,6 +71,7 @@ type CurrentView =
   | { type: 'channel'; subscription: Subscription }
   | { type: 'subscriptions' }
   | { type: 'feed' }
+  | { type: 'recommended' }
   | { type: 'search' }
   | { type: 'none' };
 
@@ -84,7 +85,7 @@ type FeedVideo = {
   viewCount: number;
 };
 
-type SubscriptionFeed = {
+type StaticFeedData = {
   generatedAt: string;
   videos: FeedVideo[];
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
         "vite": "^6.0.5",
-        "wrangler": "^4.83.0"
+        "wrangler": "^4.83.0",
+        "youtubei.js": "^17.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -343,6 +344,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
@@ -3938,6 +3946,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -5976,6 +5994,20 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youtubei.js": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-17.0.1.tgz",
+      "integrity": "sha512-1lO4b8UqMDzE0oh2qEGzbBOd4UYRdxn/4PdpRM7BGTHxM6ddsEsKZTu90jp8V9FHVgC2h1UirQyqoqLiKwl+Zg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/LuanRT"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "meriyah": "^6.1.4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5",
-    "wrangler": "^4.83.0"
+    "wrangler": "^4.83.0",
+    "youtubei.js": "^17.0.1"
   }
 }

--- a/public/recommended-feed.json
+++ b/public/recommended-feed.json
@@ -1,0 +1,4 @@
+{
+  "generatedAt": "",
+  "videos": []
+}

--- a/scripts/fetch-recommended.mjs
+++ b/scripts/fetch-recommended.mjs
@@ -1,0 +1,186 @@
+import { writeFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Innertube } from "youtubei.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const OUTPUT_PATH = resolve(ROOT, "public/recommended-feed.json");
+const MAX_VIDEOS = 50;
+const MIN_VIDEOS = 10;
+const MAX_CONTINUATIONS = 6;
+const YOUTUBE_COOKIE = process.env.YOUTUBE_COOKIE ?? null;
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID ?? null;
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET ?? null;
+const GOOGLE_REFRESH_TOKEN = process.env.GOOGLE_REFRESH_TOKEN ?? null;
+
+const VIDEO_ID_RE = /^[\w-]{11}$/;
+
+const fetchAccessToken = async () => {
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_REFRESH_TOKEN) {
+    throw new Error(
+      "Missing GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / GOOGLE_REFRESH_TOKEN env vars."
+    );
+  }
+  const params = new URLSearchParams({
+    client_id: GOOGLE_CLIENT_ID,
+    client_secret: GOOGLE_CLIENT_SECRET,
+    refresh_token: GOOGLE_REFRESH_TOKEN,
+    grant_type: "refresh_token",
+  });
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Token refresh failed (HTTP ${res.status}): ${body}`);
+  }
+  const data = await res.json();
+  return data.access_token;
+};
+
+// Pull plain video IDs out of a home-feed page. YouTube A/B tests two item
+// representations (classic Video nodes and the newer LockupView), so accept
+// both; Shorts, Mixes, and playlists are excluded here by node type, and the
+// 11-char check drops playlist/mix IDs that slip through.
+const videoIdsFromFeed = (feed) => {
+  const ids = [];
+  const memo = feed.page?.contents_memo;
+  for (const node of memo?.get("Video") ?? []) {
+    if (VIDEO_ID_RE.test(node.video_id ?? node.id ?? "")) {
+      ids.push(node.video_id ?? node.id);
+    }
+  }
+  for (const node of memo?.get("LockupView") ?? []) {
+    if (node.content_type === "VIDEO" && VIDEO_ID_RE.test(node.content_id ?? "")) {
+      ids.push(node.content_id);
+    }
+  }
+  return ids;
+};
+
+const fetchHomeFeedIds = async () => {
+  if (!YOUTUBE_COOKIE) {
+    throw new Error("Missing YOUTUBE_COOKIE env var (logged-in youtube.com Cookie header).");
+  }
+  // retrieve_player: false — the player JS is only needed for stream
+  // deciphering, and fetching it is an extra request that can fail.
+  const yt = await Innertube.create({ cookie: YOUTUBE_COOKIE, retrieve_player: false });
+
+  // Verify the cookie actually authenticates — with an expired cookie YouTube
+  // silently serves the logged-out (generic) home feed, which we never want
+  // to publish as "recommended".
+  try {
+    await yt.account.getInfo();
+  } catch (err) {
+    throw new Error(
+      `YouTube cookie appears invalid or expired (account check failed: ${err.message}). ` +
+        "Re-export the Cookie header from a logged-in youtube.com session and update the YOUTUBE_COOKIE secret."
+    );
+  }
+
+  const seen = new Set();
+  const ids = [];
+  let feed = await yt.getHomeFeed();
+  for (let i = 0; ; i++) {
+    for (const id of videoIdsFromFeed(feed)) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+    // Overshoot the target so we still have 50 after dropping live streams
+    // and stray Shorts during hydration.
+    if (ids.length >= MAX_VIDEOS * 1.5) break;
+    if (i >= MAX_CONTINUATIONS || !feed.has_continuation) break;
+    try {
+      feed = await feed.getContinuation();
+    } catch (err) {
+      console.warn(`[home] continuation failed: ${err.message}`);
+      break;
+    }
+  }
+  return ids;
+};
+
+const convertDurationToSeconds = (duration) => {
+  const match = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/.exec(duration ?? "");
+  if (!match) return 0;
+  const [, h, m, s] = match;
+  return (Number(h) || 0) * 3600 + (Number(m) || 0) * 60 + (Number(s) || 0);
+};
+
+// Hydrate IDs through the official Data API so titles, dates, and view counts
+// come from a stable source — only the ID harvesting depends on Innertube.
+const hydrateVideos = async (accessToken, ids) => {
+  const byId = new Map();
+  for (let i = 0; i < ids.length; i += 50) {
+    const chunk = ids.slice(i, i + 50);
+    const url =
+      `https://www.googleapis.com/youtube/v3/videos` +
+      `?part=snippet,contentDetails,statistics&maxResults=50&id=${chunk.join(",")}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`videos.list failed (HTTP ${res.status}): ${body}`);
+    }
+    const data = await res.json();
+    for (const item of data.items ?? []) byId.set(item.id, item);
+  }
+
+  const videos = [];
+  for (const id of ids) {
+    const item = byId.get(id);
+    if (!item) continue;
+    const s = item.snippet;
+    if (s.liveBroadcastContent && s.liveBroadcastContent !== "none") continue;
+    const durationSeconds = convertDurationToSeconds(item.contentDetails?.duration);
+    if (durationSeconds > 0 && durationSeconds <= 61) continue; // Shorts
+    videos.push({
+      id,
+      title: s.title,
+      channel: s.channelTitle ?? "",
+      channelId: s.channelId ?? "",
+      thumbnail:
+        s.thumbnails?.high?.url ??
+        s.thumbnails?.default?.url ??
+        `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
+      releaseDate: s.publishedAt,
+      viewCount: Number(item.statistics?.viewCount ?? 0),
+    });
+  }
+  return videos;
+};
+
+const main = async () => {
+  console.log("Fetching home feed recommendations via Innertube…");
+  const ids = await fetchHomeFeedIds();
+  console.log(`Collected ${ids.length} candidate video IDs.`);
+
+  console.log("Authenticating with Google…");
+  const accessToken = await fetchAccessToken();
+  console.log("Hydrating video details from YouTube Data API…");
+  const videos = (await hydrateVideos(accessToken, ids)).slice(0, MAX_VIDEOS);
+  if (videos.length < MIN_VIDEOS) {
+    console.error(
+      `Only ${videos.length} videos survived hydration (need ${MIN_VIDEOS}). Aborting without writing.`
+    );
+    process.exit(1);
+  }
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    videos,
+  };
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, JSON.stringify(payload, null, 2) + "\n");
+  console.log(`Wrote ${videos.length} videos to ${OUTPUT_PATH}`);
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -5,7 +5,7 @@ import Nav from "./Nav";
 import Sidebar from "./Sidebar";
 import Search from "./Search";
 import Subscriptions from "./Subscriptions";
-import SubscriptionFeed from "./SubscriptionFeed";
+import StaticFeed from "./StaticFeed";
 import VideoViewer from "./VideoViewer";
 import Videos from "./Videos";
 
@@ -35,6 +35,8 @@ export default function HomePage() {
 
     if (routeType === "subscriptions") {
       setCurrentView({ type: "subscriptions" });
+    } else if (routeType === "recommended") {
+      setCurrentView({ type: "recommended" });
     } else if (routeType === "search") {
       setCurrentView({ type: "search" });
     } else if (routeType === "channel" && routeId) {
@@ -98,7 +100,10 @@ export default function HomePage() {
   };
 
   const renderMain = () => {
-    if (currentView.type === "feed") return <SubscriptionFeed />;
+    if (currentView.type === "feed")
+      return <StaticFeed title="Recent Feed" src="/subscription-feed.json" sortable />;
+    if (currentView.type === "recommended")
+      return <StaticFeed title="Recommended" src="/recommended-feed.json" />;
     if (currentView.type === "subscriptions") return <Subscriptions />;
     if (currentView.type === "search") return <Search />;
     return <Videos />;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ export default function Sidebar() {
   const setVideoViewerPip = useStore((state) => state.setVideoViewerPip);
 
   const isFeed = currentView.type === "feed";
+  const isRecommended = currentView.type === "recommended";
   const isSubscriptions = currentView.type === "subscriptions";
   const isSearch = currentView.type === "search";
 
@@ -96,6 +97,19 @@ export default function Sidebar() {
           }}
         >
           Recent Feed
+        </button>
+        <button
+          className={`w-full p-2 rounded-md hover:bg-neutral/10 text-base text-left font-semibold ${isRecommended ? "bg-neutral/10" : ""}`}
+          onClick={() => {
+            setCurrentView({ type: "recommended" });
+            setSidebarOpen(false);
+            if (window.innerWidth < 768 && viewingVideo) setVideoViewerPip(true);
+            const url = new URL(window.location.href);
+            url.pathname = "/recommended";
+            window.history.pushState({}, "", url.toString());
+          }}
+        >
+          Recommended
         </button>
         <button
           className={`w-full p-2 rounded-md hover:bg-neutral/10 text-base text-left font-semibold ${isSubscriptions ? "bg-neutral/10" : ""}`}

--- a/src/components/StaticFeed.tsx
+++ b/src/components/StaticFeed.tsx
@@ -18,7 +18,15 @@ const toViewerVideo = (v: FeedVideo): Video => ({
   selected: false,
 });
 
-export default function SubscriptionFeed() {
+type Props = {
+  title: string;
+  src: string;
+  // When false the JSON array order is meaningful (recommendation ranking),
+  // so the sort dropdown is hidden and no sorting is applied.
+  sortable?: boolean;
+};
+
+export default function StaticFeed({ title, src, sortable = false }: Props) {
   const gridView = useStore((state) => state.gridView);
   const viewingVideo = useStore((state) => state.viewingVideo);
   const setViewingVideo = useStore((state) => state.setViewingVideo);
@@ -29,10 +37,10 @@ export default function SubscriptionFeed() {
   const setCurrentView = useStore((state) => state.setCurrentView);
 
   useEffect(() => {
-    setSort("releaseDate");
-  }, [setSort]);
+    if (sortable) setSort("releaseDate");
+  }, [sortable, setSort]);
 
-  const [feed, setFeed] = useState<SubscriptionFeed | null>(null);
+  const [feed, setFeed] = useState<StaticFeedData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
@@ -47,6 +55,7 @@ export default function SubscriptionFeed() {
 
   const sortedVideos = useMemo(() => {
     if (!feed) return [];
+    if (!sortable) return feed.videos;
     return [...feed.videos].sort((a, b) => {
       switch (sort) {
         case "title":
@@ -59,7 +68,7 @@ export default function SubscriptionFeed() {
           return 0;
       }
     });
-  }, [feed, sort]);
+  }, [feed, sort, sortable]);
 
   const handleDragStart = (e: React.DragEvent, video: FeedVideo) => {
     e.dataTransfer.setData(
@@ -81,12 +90,15 @@ export default function SubscriptionFeed() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/subscription-feed.json", { cache: "no-cache" })
+    setFeed(null);
+    setError(null);
+    setSelectedIds(new Set());
+    fetch(src, { cache: "no-cache" })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
-      .then((data: SubscriptionFeed) => {
+      .then((data: StaticFeedData) => {
         if (!cancelled) setFeed(data);
       })
       .catch((err) => {
@@ -95,7 +107,7 @@ export default function SubscriptionFeed() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [src]);
 
   const handleChannelClick = useCallback((channelId: string) => {
     const match = subscriptions.find((s) => s.channelId === channelId);
@@ -117,7 +129,7 @@ export default function SubscriptionFeed() {
         <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-3 mb-4">
           <div className="flex items-center gap-3 min-w-0">
             <h2 className="font-bold text-lg md:text-xl truncate">
-              Recent Feed
+              {title}
             </h2>
             {generatedLabel && (
               <p className="text-xs text-base-content/60">
@@ -133,6 +145,7 @@ export default function SubscriptionFeed() {
                 setSelectedIds(new Set(feed.videos.map((v) => v.id)))
               }
               onDeselectAll={() => setSelectedIds(new Set())}
+              hideSort={!sortable}
               moveDropdown={
                 <MoveDropdown
                   selectedVideoResourceIds={Array.from(selectedIds)}
@@ -153,8 +166,7 @@ export default function SubscriptionFeed() {
           )}
           {feed && feed.videos.length === 0 && (
             <p className="text-sm text-base-content/60">
-              The feed is empty. Run the daily job or populate
-              <code className="mx-1">data/channels.json</code>.
+              The feed is empty. Run the daily refresh job to populate it.
             </p>
           )}
           {feed && feed.videos.length > 0 && (

--- a/src/components/VideoActions.tsx
+++ b/src/components/VideoActions.tsx
@@ -9,6 +9,7 @@ type Props = {
   onDeselectAll: () => void;
   onDelete?: () => void;
   moveDropdown?: ReactNode;
+  hideSort?: boolean;
 };
 
 export default function VideoActions({
@@ -18,6 +19,7 @@ export default function VideoActions({
   onDeselectAll,
   onDelete,
   moveDropdown,
+  hideSort,
 }: Props) {
   const gridView = useStore((state) => state.gridView);
   const setGridView = useStore((state) => state.setGridView);
@@ -40,7 +42,7 @@ export default function VideoActions({
           Delete ({selectedCount})
         </button>
       )}
-      {selectedCount === 0 && <SortDropdown />}
+      {selectedCount === 0 && !hideSort && <SortDropdown />}
       {selectedCount === 0 && (
         <button
           className={`btn btn-sm md:btn-md btn-square ${gridView ? "btn-primary" : "btn-neutral"}`}


### PR DESCRIPTION
## Summary

Adds a new "Recommended" feed view that surfaces videos from the authenticated user's YouTube home page, complementing the existing subscription-based "Recent Feed". The recommended feed is generated via a new offline pipeline script that harvests video IDs from YouTube's home feed using Innertube, then hydrates metadata from the official YouTube Data API.

## Key Changes

- **New script `scripts/fetch-recommended.mjs`**: Fetches the authenticated user's YouTube home feed via Innertube, extracts video IDs, and hydrates full metadata (title, channel, thumbnail, view count, publish date) from the YouTube Data API. Filters out live streams and Shorts, targets 50 videos per run.

- **Refactored `SubscriptionFeed.tsx` → `StaticFeed.tsx`**: Generalized the component to accept `title`, `src` (JSON file path), and `sortable` props. The "Recent Feed" view remains sortable; the new "Recommended" view preserves ranking order from the JSON (no sort dropdown). Both consume the same `StaticFeedData` type.

- **UI additions**: Added "Recommended" button to sidebar that navigates to `/recommended` and renders the recommended feed. Updated routing in `HomePage.tsx` to handle the new view type.

- **GitHub Actions workflow**: Extended `fetch-feed.yml` to run the new `fetch-recommended.mjs` script with `continue-on-error: true` (expired YouTube cookies don't block the subscription feed refresh). Both feeds are committed together.

- **Type updates**: Renamed `SubscriptionFeed` → `StaticFeedData` in `global.d.ts`, added `recommended` to `CurrentView` discriminated union, added `hideSort` prop to `VideoActions`.

- **Dependencies**: Added `youtubei.js` v17.0.1 for Innertube API access.

## Implementation Details

- The recommended feed script validates the YouTube cookie by calling `account.getInfo()` before proceeding, ensuring an expired/invalid cookie fails fast rather than silently serving the logged-out feed.
- Video ID extraction handles two YouTube A/B test representations (`Video` nodes and `LockupView`), filtering by 11-character ID format to exclude playlists/mixes.
- Shorts are filtered during hydration by checking `contentDetails.duration` (≤61 seconds).
- The script overshoots the target (50 × 1.5 = 75 candidates) to account for filtering, then slices to exactly 50 in the final output.
- Recommended feed is read-only (no sorting, no drag-to-playlist) to preserve ranking semantics from YouTube's algorithm.

https://claude.ai/code/session_01XDpfiWNsaFTEuye9CcgxTt