### PR TITLE
Improve recommended feed coverage and bump deprecated action versions

### DIFF
--- a/.github/workflows/fetch-feed.yml
+++ b/.github/workflows/fetch-feed.yml
@@ -12,9 +12,9 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/scripts/fetch-recommended.mjs
+++ b/scripts/fetch-recommended.mjs
@@ -8,7 +8,7 @@ const ROOT = resolve(__dirname, "..");
 const OUTPUT_PATH = resolve(ROOT, "public/recommended-feed.json");
 const MAX_VIDEOS = 50;
 const MIN_VIDEOS = 10;
-const MAX_CONTINUATIONS = 6;
+const MAX_CONTINUATIONS = 12;
 const YOUTUBE_COOKIE = process.env.YOUTUBE_COOKIE ?? null;
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID ?? null;
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET ?? null;
@@ -85,15 +85,22 @@ const fetchHomeFeedIds = async () => {
   const ids = [];
   let feed = await yt.getHomeFeed();
   for (let i = 0; ; i++) {
+    const before = ids.length;
     for (const id of videoIdsFromFeed(feed)) {
       if (seen.has(id)) continue;
       seen.add(id);
       ids.push(id);
     }
+    console.log(`[home] page ${i + 1}: +${ids.length - before} videos (${ids.length} total)`);
     // Overshoot the target so we still have 50 after dropping live streams
     // and stray Shorts during hydration.
     if (ids.length >= MAX_VIDEOS * 1.5) break;
-    if (i >= MAX_CONTINUATIONS || !feed.has_continuation) break;
+    if (i >= MAX_CONTINUATIONS || !feed.has_continuation) {
+      console.log(
+        `[home] stopping: ${!feed.has_continuation ? "no further continuation available" : "continuation budget exhausted"}`
+      );
+      break;
+    }
     try {
       feed = await feed.getContinuation();
     } catch (err) {


### PR DESCRIPTION
## Summary

Follow-ups from the first production run of the recommended feed pipeline (#17), which succeeded end-to-end but only collected 24 candidate videos (22 after filtering) instead of the 50 target.

## Changes

- **Double the home-feed continuation budget (6 → 12 pages).** YouTube pads the Home feed with non-video shelves (chip shelves, "talk to recs" prompts, Shorts shelves), so each page yields fewer plain videos than expected and the previous budget ran out early.
- **Per-page harvest logging.** Each page now logs how many new video IDs it contributed plus the reason the loop stopped (continuation exhausted vs. budget reached), so future shortfalls are diagnosable straight from the Actions log.
- **Bump `actions/checkout` and `actions/setup-node` to v5.** The run emitted a deprecation warning: Node 20 actions get force-migrated to Node 24 on June 16, 2026. v5 of both actions supports the new runtime.

https://claude.ai/code/session_01XDpfiWNsaFTEuye9CcgxTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDpfiWNsaFTEuye9CcgxTt)_