### PR TITLE
Update site downtime window from 10:00 to 12:00 Europe/London

### DIFF
--- a/.github/workflows/fetch-feed.yml
+++ b/.github/workflows/fetch-feed.yml
@@ -2,7 +2,10 @@ name: Refresh subscription feed
 
 on:
   schedule:
-    - cron: "0 12 * * *"
+    # 11:20 Europe/London in summer (BST), 10:20 in winter. Scheduled ~40 min
+    # before the site reopens at 12:00 because GitHub cron triggers are often
+    # 5-20+ minutes late and the run + Pages deploy needs a few more minutes.
+    - cron: "20 10 * * *"
   workflow_dispatch:
 
 permissions:

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,7 +7,7 @@ import DowntimeNotice from "./DowntimeNotice";
 import HomePage from "./HomePage";
 import LandingPage from "./LandingPage";
 
-// Site is offline between 22:00 and 10:00 Europe/London time.
+// Site is offline between 22:00 and 12:00 Europe/London time.
 const isDowntime = () => {
   const hour = Number(
     new Intl.DateTimeFormat("en-GB", {
@@ -16,7 +16,7 @@ const isDowntime = () => {
       hourCycle: "h23",
     }).format(new Date()),
   );
-  return hour >= 22 || hour < 10;
+  return hour >= 22 || hour < 12;
 };
 
 const App = () => {


### PR DESCRIPTION
## Summary
Updates the site downtime window and related automation to reflect a new reopening time of 12:00 Europe/London (previously 10:00).

## Changes
- **App.tsx**: Updated `isDowntime()` logic to mark the site as offline between 22:00 and 12:00 Europe/London time (was 10:00)
- **fetch-feed.yml**: Adjusted the subscription feed refresh schedule from 12:00 UTC to 10:20 UTC to account for GitHub Actions cron delays and deployment time, ensuring the feed is ready before the site reopens at 12:00 Europe/London. Added explanatory comments about the timing rationale.

## Implementation details
The cron schedule change includes a ~40 minute buffer before the 12:00 reopening to accommodate:
- GitHub Actions cron triggers being 5-20+ minutes late
- Time needed for the feed fetch script to run
- Time needed for the GitHub Pages deployment to complete

This ensures the subscription feed is fresh and deployed by the time users can access the site.

https://claude.ai/code/session_015ew6qNzyyS664A5Q5KPMUw