### PR TITLE
Adjust downtime window from 22:00–12:00 to 22:00–10:00

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,7 +7,7 @@ import DowntimeNotice from "./DowntimeNotice";
 import HomePage from "./HomePage";
 import LandingPage from "./LandingPage";
 
-// Site is offline between 22:00 and 12:00 Europe/London time.
+// Site is offline between 22:00 and 10:00 Europe/London time.
 const isDowntime = () => {
   const hour = Number(
     new Intl.DateTimeFormat("en-GB", {
@@ -16,7 +16,7 @@ const isDowntime = () => {
       hourCycle: "h23",
     }).format(new Date()),
   );
-  return hour >= 22 || hour < 12;
+  return hour >= 22 || hour < 10;
 };
 
 const App = () => {


### PR DESCRIPTION
## Summary
Updates the site downtime maintenance window to end at 10:00 Europe/London time instead of 12:00.

## Changes
- Updated the downtime notice comment from "22:00 and 12:00" to "22:00 and 10:00"
- Modified the `isDowntime()` function logic to check `hour < 10` instead of `hour < 12`

This shifts the end of the maintenance window 2 hours earlier, so the site will be available starting at 10:00 instead of 12:00 Europe/London time each day.

https://claude.ai/code/session_01Fr9SUudCwvfLn4G8BAYmBs