### PR TITLE
Fix video player overflow on iPad-width viewports

### DIFF
--- a/src/components/VideoViewer.tsx
+++ b/src/components/VideoViewer.tsx
@@ -215,7 +215,7 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
       className={
         pip
           ? `fixed bottom-4 right-4 w-64 md:w-80 z-50 flex-col bg-base-100 border border-base-300 rounded-lg shadow-2xl overflow-hidden ${sidebarOpen ? "hidden md:flex" : "flex"}`
-          : `${expanded ? "w-full" : "w-full xl:w-1/2"} h-full flex flex-col xl:border-l border-base-300 bg-base-100`
+          : `${expanded ? "w-full" : "w-full xl:w-1/2"} min-w-0 h-full flex flex-col xl:border-l border-base-300 bg-base-100`
       }
     >
       <div className={`flex items-center justify-between border-b border-base-300 ${pip ? "p-2" : "p-4"}`}>
@@ -289,7 +289,7 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
       </div>
       <div className={pip ? "" : "flex-1 overflow-y-auto p-4"}>
         <div className="w-full flex justify-center">
-          <div className={pip ? "w-full aspect-video relative" : "w-full aspect-video max-h-[calc(100dvh-180px)] max-w-[calc((100dvh-180px)*16/9)] relative"}>
+          <div className={pip ? "w-full aspect-video relative" : "w-full min-w-0 aspect-video max-h-[calc(100dvh-180px)] max-w-[calc((100dvh-180px)*16/9)] relative"}>
             <iframe
               ref={iframeRef}
               className="absolute inset-0 w-full h-full"


### PR DESCRIPTION
The VideoViewer player wrapper uses aspect-video with max-height. When
the width-derived height exceeds that max-height, WebKit derives a
transferred minimum width (max-height * 16/9) for the aspect-ratio flex
item. That minimum propagated up the flex chain, preventing the viewer
from shrinking beside the sidebar, so the player overflowed the right
edge on iPad-sized (below-xl) viewports.

Add min-w-0 to the player wrapper to drop the transferred minimum width,
and to the VideoViewer root so it can shrink within the main flex row.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PzwkutcCCPC8oZKK5dJixy