### PR TITLE
Update downtime window from 10:00 AM to 12:00 PM

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,7 +7,7 @@ import DowntimeNotice from "./DowntimeNotice";
 import HomePage from "./HomePage";
 import LandingPage from "./LandingPage";
 
-// Site is offline between 22:00 and 10:00 Europe/London time.
+// Site is offline between 22:00 and 12:00 Europe/London time.
 const isDowntime = () => {
   const hour = Number(
     new Intl.DateTimeFormat("en-GB", {
@@ -16,7 +16,7 @@ const isDowntime = () => {
       hourCycle: "h23",
     }).format(new Date()),
   );
-  return hour >= 22 || hour < 10;
+  return hour >= 22 || hour < 12;
 };
 
 const App = () => {

--- a/src/components/DowntimeNotice.tsx
+++ b/src/components/DowntimeNotice.tsx
@@ -4,7 +4,7 @@ const DowntimeNotice = () => {
       <div className="max-w-md text-center">
         <h1 className="text-3xl font-bold mb-4">We&apos;re taking a break</h1>
         <p className="text-base-content/80">
-          This site is unavailable between 10:00 PM and 10:00 AM (UK time).
+          This site is unavailable between 10:00 PM and 12:00 PM (UK time).
           Please come back during opening hours.
         </p>
       </div>


### PR DESCRIPTION
## Summary
Updates the site's scheduled downtime window to end at 12:00 PM (noon) instead of 10:00 AM UK time.

## Changes
- **App.tsx**: Updated the `isDowntime()` function logic to check `hour < 12` instead of `hour < 10`, and updated the corresponding comment to reflect the new 22:00–12:00 downtime window
- **DowntimeNotice.tsx**: Updated the user-facing message to display "10:00 PM and 12:00 PM (UK time)" instead of "10:00 PM and 10:00 AM (UK time)"

## Details
The downtime check now correctly identifies the offline period as 22:00 (10:00 PM) through 12:00 (noon) Europe/London time, with both the logic and user-facing messaging aligned to the new schedule.

https://claude.ai/code/session_01UB6xfbcYeVxWrFXpwG57vZ