### PR TITLE
Handle channel navigation by revealing channel list

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -99,6 +99,16 @@ export default function HomePage() {
     setVideoViewerPip(!videoViewerPip);
   };
 
+  // Navigating to a channel from the viewer has to reveal the channel list: drop
+  // out of full screen into the split layout, or into pip below the xl breakpoint
+  // where the viewer covers the whole pane instead of splitting it.
+  const handleChannelNavigate = () => {
+    setVideoViewerExpanded(false);
+    if (!window.matchMedia("(min-width: 1280px)").matches) {
+      setVideoViewerPip(true);
+    }
+  };
+
   const renderMain = () => {
     if (currentView.type === "feed")
       return <StaticFeed title="Recent Feed" src="/subscription-feed.json" sortable />;
@@ -123,6 +133,7 @@ export default function HomePage() {
             onExpandToggle={handleExpandToggle}
             pip={videoViewerPip}
             onPipToggle={handlePipToggle}
+            onChannelNavigate={handleChannelNavigate}
           />
         )}
       </div>

--- a/src/components/VideoViewer.tsx
+++ b/src/components/VideoViewer.tsx
@@ -16,9 +16,10 @@ interface VideoViewerProps {
   onExpandToggle?: () => void;
   pip?: boolean;
   onPipToggle?: () => void;
+  onChannelNavigate?: () => void;
 }
 
-export default function VideoViewer({ video, onClose, expanded, onExpandToggle, pip, onPipToggle }: VideoViewerProps) {
+export default function VideoViewer({ video, onClose, expanded, onExpandToggle, pip, onPipToggle, onChannelNavigate }: VideoViewerProps) {
   const accessToken = useStore((state) => state.accessToken);
   const subscriptions = useStore((state) => state.subscriptions);
   const setCurrentView = useStore((state) => state.setCurrentView);
@@ -228,6 +229,7 @@ export default function VideoViewer({ video, onClose, expanded, onExpandToggle, 
                 const match = subscriptions.find((s) => s.channelId === video.channelId);
                 const subscription = match ?? { id: "", title: video.channel, thumbnail: "", channelId: video.channelId };
                 setCurrentView({ type: "channel", subscription });
+                onChannelNavigate?.();
               }}
             >
               {video.channel}


### PR DESCRIPTION
## Summary
When navigating to a channel from the video viewer, the UI now automatically adjusts the layout to reveal the channel list. This prevents the viewer from staying in expanded/full-screen mode where the channel would not be visible.

## Changes
- Added `handleChannelNavigate` callback in `HomePage` that:
  - Exits expanded view mode (`setVideoViewerExpanded(false)`)
  - Enters picture-in-picture mode on screens below the `xl` breakpoint (< 1280px) where the viewer normally covers the entire pane
  - Allows the split layout to show on larger screens where the viewer and sidebar coexist
- Updated `VideoViewer` to accept and invoke `onChannelNavigate` callback when the channel name is clicked
- Passed the new callback from `HomePage` to the `VideoViewer` component

## Implementation Details
The callback uses `window.matchMedia("(min-width: 1280px)")` to detect the breakpoint and conditionally enable PIP mode only on smaller screens, ensuring the channel list becomes visible after navigation regardless of screen size.

https://claude.ai/code/session_01MdaTFN1d5gm54X7Ypb5mKV